### PR TITLE
Fix false positives

### DIFF
--- a/assertions/src/VaultAssetTransferAccountingAssertion.a.sol
+++ b/assertions/src/VaultAssetTransferAccountingAssertion.a.sol
@@ -210,10 +210,16 @@ contract VaultAssetTransferAccountingAssertion is Assertion {
 
     /// @notice Gets the asset token address for a vault
     /// @param vault The vault address to query
-    /// @return The asset token address
+    /// @return The asset token address, or address(0) if the call fails
+    /// @dev Uses try/catch to safely handle non-ERC4626 contracts in batch items
+    ///      (e.g., Permit2, routers, or other helper contracts)
     function getAssetAddress(
         address vault
     ) internal view returns (address) {
-        return IERC4626(vault).asset();
+        try IERC4626(vault).asset() returns (address asset) {
+            return asset;
+        } catch {
+            return address(0);
+        }
     }
 }

--- a/assertions/test/backtesting/AccountHealthAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/AccountHealthAssertion.backtest.t.sol
@@ -34,7 +34,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
     }
@@ -70,7 +70,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: true,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
     }
@@ -106,7 +106,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
     }

--- a/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
@@ -29,7 +29,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -50,7 +50,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -71,7 +71,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 

--- a/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
@@ -15,7 +15,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
     address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
 
     // Block configuration
-    uint256 constant END_BLOCK = 27269658;
+    uint256 constant END_BLOCK = 27419134;
     uint256 constant BLOCK_RANGE = 3;
 
     /// @notice Backtest batch operations against mainnet EVC
@@ -52,7 +52,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -74,7 +74,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 

--- a/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
@@ -12,16 +12,18 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
 
+    address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
+
     // Block configuration
-    uint256 constant END_BLOCK = 23697612;
-    uint256 constant BLOCK_RANGE = 10;
+    uint256 constant END_BLOCK = 27269658;
+    uint256 constant BLOCK_RANGE = 3;
 
     /// @notice Backtest batch operations against mainnet EVC
     /// @dev Tests that all asset transfers are accounted for in batch operations
     function testBacktest_VaultAssetTransferAccounting_BatchOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
-                targetContract: EVC_MAINNET,
+                targetContract: EVC_LINEA,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
                 assertionCreationCode: type(VaultAssetTransferAccountingAssertion).creationCode,
@@ -29,7 +31,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -66,8 +68,9 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
                 assertionCreationCode: type(VaultAssetTransferAccountingAssertion).creationCode,
-                assertionSelector: VaultAssetTransferAccountingAssertion.assertionControlCollateralAssetTransferAccounting
-                .selector,
+                assertionSelector: VaultAssetTransferAccountingAssertion
+                    .assertionControlCollateralAssetTransferAccounting
+                    .selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,

--- a/assertions/test/backtesting/VaultExchangeRateSpikeAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultExchangeRateSpikeAssertion.backtest.t.sol
@@ -29,7 +29,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -50,7 +50,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -70,7 +70,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 

--- a/assertions/test/backtesting/VaultSharePriceAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultSharePriceAssertion.backtest.t.sol
@@ -6,31 +6,38 @@ import {BacktestingTypes} from "credible-std/utils/BacktestingTypes.sol";
 import {VaultSharePriceAssertion} from "../../src/VaultSharePriceAssertion.a.sol";
 
 /// @title VaultSharePriceAssertion Backtesting
-/// @notice Tests VaultSharePriceAssertion against historical EVC transactions on mainnet
-/// @dev Validates that share prices don't decrease unless bad debt socialization occurs
+/// @notice Tests VaultSharePriceAssertion against historical EVC transactions on mainnet and Linea
+/// @dev Validates that share prices don't decrease unless legitimate reasons exist (bad debt or interest fees)
 contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
 
-    // Block configuration
-    // uint256 constant END_BLOCK = 23697612; // call in batch
-    uint256 constant END_BLOCK = 23697590; // out of gas batch
-    uint256 constant BLOCK_RANGE = 10;
+    // EVC Linea deployment
+    address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
+
+    // Block configuration for mainnet
+    uint256 constant MAINNET_END_BLOCK = 21551000;
+    uint256 constant MAINNET_BLOCK_RANGE = 3;
+
+    // Block configuration for Linea - testing specific tx that had interest fee dilution
+    // Tx: 0x4ec425f3329c4e036c28df2d108341ad45a225edc42d22fb68dfc1ac52dc3738
+    uint256 constant LINEA_END_BLOCK = 27419134;
+    uint256 constant LINEA_BLOCK_RANGE = 1;
 
     /// @notice Backtest batch operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without bad debt for batch operations
+    /// @dev Tests that share prices don't decrease without legitimate reason for batch operations
     function testBacktest_VaultSharePrice_BatchOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
                 targetContract: EVC_MAINNET,
-                endBlock: END_BLOCK,
-                blockRange: BLOCK_RANGE,
+                endBlock: MAINNET_END_BLOCK,
+                blockRange: MAINNET_BLOCK_RANGE,
                 assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
                 assertionSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -39,19 +46,19 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     }
 
     /// @notice Backtest single call operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without bad debt for call operations
+    /// @dev Tests that share prices don't decrease without legitimate reason for call operations
     function testBacktest_VaultSharePrice_CallOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
                 targetContract: EVC_MAINNET,
-                endBlock: END_BLOCK,
-                blockRange: BLOCK_RANGE,
+                endBlock: MAINNET_END_BLOCK,
+                blockRange: MAINNET_BLOCK_RANGE,
                 assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
                 assertionSelector: VaultSharePriceAssertion.assertionCallSharePriceInvariant.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
@@ -59,22 +66,79 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     }
 
     /// @notice Backtest control collateral operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without bad debt for controlCollateral operations
+    /// @dev Tests that share prices don't decrease without legitimate reason for controlCollateral operations
     function testBacktest_VaultSharePrice_ControlCollateralOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
                 targetContract: EVC_MAINNET,
-                endBlock: END_BLOCK,
-                blockRange: BLOCK_RANGE,
+                endBlock: MAINNET_END_BLOCK,
+                blockRange: MAINNET_BLOCK_RANGE,
                 assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
                 assertionSelector: VaultSharePriceAssertion.assertionControlCollateralSharePriceInvariant.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: false
+                forkByTxHash: true
             })
         );
 
         assertEq(results.assertionFailures, 0, "Should not detect violations in healthy protocol");
+    }
+
+    /// @notice Backtest batch operations against Linea EVC - specifically tests InterestAccrued handling
+    /// @dev Tests the fix for false positive on tx 0x4ec425f3... where InterestAccrued caused share price decrease
+    /// This transaction had a USDC vault with InterestAccrued event causing legitimate ~0.0000012% share price decrease
+    function testBacktest_VaultSharePrice_Linea_BatchOperations() public {
+        // Use LINEA_RPC_URL if available, fallback to MAINNET_RPC_URL for local testing
+        string memory rpcUrl;
+        try vm.envString("LINEA_RPC_URL") returns (string memory url) {
+            rpcUrl = url;
+        } catch {
+            rpcUrl = vm.envString("MAINNET_RPC_URL");
+        }
+
+        BacktestingTypes.BacktestingResults memory results = executeBacktest(
+            BacktestingTypes.BacktestingConfig({
+                targetContract: EVC_LINEA,
+                endBlock: LINEA_END_BLOCK,
+                blockRange: LINEA_BLOCK_RANGE,
+                assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
+                assertionSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector,
+                rpcUrl: rpcUrl,
+                detailedBlocks: false,
+                useTraceFilter: false,
+                forkByTxHash: true // Fork by tx hash to get correct state for tx replay
+            })
+        );
+
+        // Should pass now that we recognize InterestAccrued as legitimate share price decrease
+        assertEq(results.assertionFailures, 0, "InterestAccrued events should be recognized as legitimate");
+    }
+
+    /// @notice Backtest call operations against Linea EVC
+    function testBacktest_VaultSharePrice_Linea_CallOperations() public {
+        // Use LINEA_RPC_URL if available, fallback to MAINNET_RPC_URL for local testing
+        string memory rpcUrl;
+        try vm.envString("LINEA_RPC_URL") returns (string memory url) {
+            rpcUrl = url;
+        } catch {
+            rpcUrl = vm.envString("MAINNET_RPC_URL");
+        }
+
+        BacktestingTypes.BacktestingResults memory results = executeBacktest(
+            BacktestingTypes.BacktestingConfig({
+                targetContract: EVC_LINEA,
+                endBlock: LINEA_END_BLOCK,
+                blockRange: LINEA_BLOCK_RANGE,
+                assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
+                assertionSelector: VaultSharePriceAssertion.assertionCallSharePriceInvariant.selector,
+                rpcUrl: rpcUrl,
+                detailedBlocks: false,
+                useTraceFilter: false,
+                forkByTxHash: true // Fork by tx hash to get correct state for tx replay
+            })
+        );
+
+        assertEq(results.assertionFailures, 0, "InterestAccrued events should be recognized as legitimate");
     }
 }

--- a/assertions/test/fuzz/VaultSharePriceAssertion.fuzz.t.sol
+++ b/assertions/test/fuzz/VaultSharePriceAssertion.fuzz.t.sol
@@ -104,7 +104,7 @@ contract VaultSharePriceAssertionFuzzTest is BaseTest {
 
         // Execute batch call - should REVERT (rate decrease exceeds 5% without bad debt)
         vm.prank(user1);
-        vm.expectRevert("VaultSharePriceAssertion: Share price decreased without bad debt socialization");
+        vm.expectRevert("VaultSharePriceAssertion: Share price decreased without legitimate reason");
         evc.batch(items);
     }
 

--- a/assertions/test/mocks/MaliciousVaults.sol
+++ b/assertions/test/mocks/MaliciousVaults.sol
@@ -16,16 +16,22 @@ contract CashThiefVault is MockEVault {
 
     constructor(MockERC20 _asset, IEVC _evc) MockEVault(_asset, _evc) {}
 
-    function setStealOnWithdraw(bool _enabled) external {
+    function setStealOnWithdraw(
+        bool _enabled
+    ) external {
         stealOnWithdraw = _enabled;
     }
 
-    function setSkipCashUpdate(bool _enabled) external {
+    function setSkipCashUpdate(
+        bool _enabled
+    ) external {
         skipCashUpdate = _enabled;
     }
 
     /// @notice Corrupt cash value manually (for testing bad state)
-    function corruptCash(uint256 newCash) external {
+    function corruptCash(
+        uint256 newCash
+    ) external {
         cash = newCash;
     }
 
@@ -60,19 +66,25 @@ contract RateManipulatorVault is MockEVault {
 
     /// @notice Set inflation to apply on next deposit
     /// @param bps Basis points to inflate (e.g., 500 = 5%)
-    function setInflationBps(uint256 bps) external {
+    function setInflationBps(
+        uint256 bps
+    ) external {
         inflationBps = bps;
     }
 
     /// @notice Set deflation to apply on next deposit
     /// @param bps Basis points to deflate (e.g., 500 = 5%)
-    function setDeflationBps(uint256 bps) external {
+    function setDeflationBps(
+        uint256 bps
+    ) external {
         deflationBps = bps;
     }
 
     /// @notice Inflate totalAssets by percentage (for testing outside of transactions)
     /// @param percentage Percentage to inflate (e.g., 10 = 10%)
-    function inflateTotalAssets(uint256 percentage) external {
+    function inflateTotalAssets(
+        uint256 percentage
+    ) external {
         uint256 current = totalAssets();
         uint256 inflation = (current * percentage) / 100;
         MockERC20(asset()).mint(address(this), inflation);
@@ -80,7 +92,9 @@ contract RateManipulatorVault is MockEVault {
 
     /// @notice Deflate totalAssets by percentage (for testing outside of transactions)
     /// @param percentage Percentage to deflate (e.g., 10 = 10%)
-    function deflateTotalAssets(uint256 percentage) external {
+    function deflateTotalAssets(
+        uint256 percentage
+    ) external {
         uint256 current = totalAssets();
         uint256 deflation = (current * percentage) / 100;
         // Burn tokens to simulate loss
@@ -109,6 +123,22 @@ contract RateManipulatorVault is MockEVault {
     }
 }
 
+/// @title MockNonVaultContract
+/// @notice A contract that doesn't implement ERC4626 (simulates Permit2, routers, etc.)
+/// @dev Used for testing that assertions gracefully handle non-vault contracts in batches
+contract MockNonVaultContract {
+    event SomethingDone(address sender);
+
+    /// @notice A simple function that doesn't have anything to do with vaults
+    function doSomething() external returns (bool) {
+        emit SomethingDone(msg.sender);
+        return true;
+    }
+
+    // Note: This contract intentionally does NOT have an asset() function
+    // to test that assertions handle this gracefully
+}
+
 /// @title EventManipulatorVault
 /// @notice Malicious vault that transfers assets without emitting proper events
 /// @dev Used for testing VaultAssetTransferAccountingAssertion
@@ -121,19 +151,27 @@ contract EventManipulatorVault is MockEVault {
 
     constructor(IERC20 _asset, IEVC _evc) MockEVault(_asset, _evc) {}
 
-    function setShouldSkipWithdrawEvent(bool value) external {
+    function setShouldSkipWithdrawEvent(
+        bool value
+    ) external {
         shouldSkipWithdrawEvent = value;
     }
 
-    function setShouldSkipBorrowEvent(bool value) external {
+    function setShouldSkipBorrowEvent(
+        bool value
+    ) external {
         shouldSkipBorrowEvent = value;
     }
 
-    function setShouldUnderreportAmount(bool value) external {
+    function setShouldUnderreportAmount(
+        bool value
+    ) external {
         shouldUnderreportAmount = value;
     }
 
-    function setShouldMakeExtraTransfer(bool value) external {
+    function setShouldMakeExtraTransfer(
+        bool value
+    ) external {
         shouldMakeExtraTransfer = value;
     }
 


### PR DESCRIPTION
Bugs Fixed:
VaultAssetTransferAccountingAssertion - Added try/catch for non-ERC4626 contracts (Permit2) and recognition of nested vault deposits
VaultSharePriceAssertion - Added InterestAccrued event detection for legitimate share price decreases from EVK fee mechanism
Other Improvements:
Updated all backtest files to use forkByTxHash: true for correct transaction replay
Added unit tests for new scenarios
Updated error messages and documentation