### PR TITLE
fix(VaultSharePriceAssertion): use Euler's VIRTUAL_DEPOSIT formula 

### DIFF
--- a/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
@@ -66,8 +66,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
                 assertionCreationCode: type(VaultAccountingIntegrityAssertion).creationCode,
-                assertionSelector: VaultAccountingIntegrityAssertion.assertionControlCollateralAccountingIntegrity
-                    .selector,
+                assertionSelector: VaultAccountingIntegrityAssertion.assertionControlCollateralAccountingIntegrity.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,

--- a/assertions/test/backtesting/VaultSharePriceAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultSharePriceAssertion.backtest.t.sol
@@ -6,8 +6,8 @@ import {BacktestingTypes} from "credible-std/utils/BacktestingTypes.sol";
 import {VaultSharePriceAssertion} from "../../src/VaultSharePriceAssertion.a.sol";
 
 /// @title VaultSharePriceAssertion Backtesting
-/// @notice Tests VaultSharePriceAssertion against historical EVC transactions on mainnet and Linea
-/// @dev Validates that share prices don't decrease unless legitimate reasons exist (bad debt or interest fees)
+/// @notice Tests VaultSharePriceAssertion against historical EVC transactions
+/// @dev Update the block range constants to test different historical periods
 contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
@@ -15,17 +15,15 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     // EVC Linea deployment
     address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
 
-    // Block configuration for mainnet
+    // Block configuration for mainnet - adjust these to test different ranges
     uint256 constant MAINNET_END_BLOCK = 21551000;
     uint256 constant MAINNET_BLOCK_RANGE = 3;
 
-    // Block configuration for Linea - testing specific tx that had interest fee dilution
-    // Tx: 0x4ec425f3329c4e036c28df2d108341ad45a225edc42d22fb68dfc1ac52dc3738
+    // Block configuration for Linea - adjust these to test different ranges
     uint256 constant LINEA_END_BLOCK = 27419134;
     uint256 constant LINEA_BLOCK_RANGE = 1;
 
     /// @notice Backtest batch operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without legitimate reason for batch operations
     function testBacktest_VaultSharePrice_BatchOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
@@ -46,7 +44,6 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     }
 
     /// @notice Backtest single call operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without legitimate reason for call operations
     function testBacktest_VaultSharePrice_CallOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
@@ -66,7 +63,6 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
     }
 
     /// @notice Backtest control collateral operations against mainnet EVC
-    /// @dev Tests that share prices don't decrease without legitimate reason for controlCollateral operations
     function testBacktest_VaultSharePrice_ControlCollateralOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
             BacktestingTypes.BacktestingConfig({
@@ -85,9 +81,37 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
         assertEq(results.assertionFailures, 0, "Should not detect violations in healthy protocol");
     }
 
-    /// @notice Backtest batch operations against Linea EVC - specifically tests InterestAccrued handling
-    /// @dev Tests the fix for false positive on tx 0x4ec425f3... where InterestAccrued caused share price decrease
-    /// This transaction had a USDC vault with InterestAccrued event causing legitimate ~0.0000012% share price decrease
+    /// @notice Regression test for Linea tx 0x4ec425f3329c4e036c28df2d108341ad45a225edc42d22fb68dfc1ac52dc3738
+    /// @dev This specific transaction triggered a false positive before the VIRTUAL_DEPOSIT formula was implemented.
+    /// Keeping as a regression test with hardcoded values to ensure the fix remains effective.
+    function testBacktest_VaultSharePrice_Linea_RegressionTest() public {
+        // Use LINEA_RPC_URL if available, fallback to MAINNET_RPC_URL for local testing
+        string memory rpcUrl;
+        try vm.envString("LINEA_RPC_URL") returns (string memory url) {
+            rpcUrl = url;
+        } catch {
+            rpcUrl = vm.envString("MAINNET_RPC_URL");
+        }
+
+        // Hardcoded values for the specific regression test transaction
+        BacktestingTypes.BacktestingResults memory results = executeBacktest(
+            BacktestingTypes.BacktestingConfig({
+                targetContract: EVC_LINEA,
+                endBlock: 27419134, // Block containing tx 0x4ec425f3...
+                blockRange: 1,
+                assertionCreationCode: type(VaultSharePriceAssertion).creationCode,
+                assertionSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector,
+                rpcUrl: rpcUrl,
+                detailedBlocks: false,
+                useTraceFilter: false,
+                forkByTxHash: true
+            })
+        );
+
+        assertEq(results.assertionFailures, 0, "Regression test should pass");
+    }
+
+    /// @notice Backtest batch operations against Linea EVC
     function testBacktest_VaultSharePrice_Linea_BatchOperations() public {
         // Use LINEA_RPC_URL if available, fallback to MAINNET_RPC_URL for local testing
         string memory rpcUrl;
@@ -107,12 +131,11 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
                 rpcUrl: rpcUrl,
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: true // Fork by tx hash to get correct state for tx replay
+                forkByTxHash: true
             })
         );
 
-        // Should pass now that we recognize InterestAccrued as legitimate share price decrease
-        assertEq(results.assertionFailures, 0, "InterestAccrued events should be recognized as legitimate");
+        assertEq(results.assertionFailures, 0, "Should not detect violations in healthy protocol");
     }
 
     /// @notice Backtest call operations against Linea EVC
@@ -135,10 +158,10 @@ contract VaultSharePriceAssertionBacktest is CredibleTestWithBacktesting {
                 rpcUrl: rpcUrl,
                 detailedBlocks: false,
                 useTraceFilter: false,
-                forkByTxHash: true // Fork by tx hash to get correct state for tx replay
+                forkByTxHash: true
             })
         );
 
-        assertEq(results.assertionFailures, 0, "InterestAccrued events should be recognized as legitimate");
+        assertEq(results.assertionFailures, 0, "Should not detect violations in healthy protocol");
     }
 }

--- a/assertions/test/fuzz/VaultSharePriceAssertion.fuzz.t.sol
+++ b/assertions/test/fuzz/VaultSharePriceAssertion.fuzz.t.sol
@@ -104,7 +104,7 @@ contract VaultSharePriceAssertionFuzzTest is BaseTest {
 
         // Execute batch call - should REVERT (rate decrease exceeds 5% without bad debt)
         vm.prank(user1);
-        vm.expectRevert("VaultSharePriceAssertion: Share price decreased without legitimate reason");
+        vm.expectRevert("VaultSharePriceAssertion: Share price decreased without bad debt socialization");
         evc.batch(items);
     }
 


### PR DESCRIPTION
The assertion was incorrectly calculating share prices using the standard ERC4626 formula (totalAssets/totalSupply) instead of Euler's formula which includes VIRTUAL_DEPOSIT_AMOUNT (1e6):

  exchangeRate = (totalAssets + 1e6) / (totalSupply + 1e6)

This caused false positives on small vaults (~279 USDC) where the VIRTUAL_DEPOSIT has a significant impact on the exchange rate calculation. Without the virtual deposit, a deposit at ratio 1.0694 into a vault with existing ratio 1.0695 appeared to decrease the share price. With the correct formula, the share price actually increases.

Changes:
- Add VIRTUAL_DEPOSIT_AMOUNT constant (1e6) matching EVK ConversionHelpers.sol
- Update getSharePrice() to use Euler's exchange rate formula
- Remove InterestAccrued event detection (no longer needed with correct formula)
- Rename checkForLegitimateSharePriceDecrease() to checkForBadDebtSocialization()
- Update terminology throughout: 'legitimate reason' → 'bad debt socialization'
- Add regression test replicating the exact Linea tx that triggered the false positive
- Update backtest file with generic tests and specific regression test

Root cause: Euler uses VIRTUAL_DEPOSIT to prevent first depositor attacks. The 1e6 virtual deposit is added to both numerator and denominator in exchange rate calculations. For small vaults, this materially affects the rate calculation direction.