### PR TITLE
add IPerspective vault verification to filter non-vault contracts

### DIFF
--- a/assertions/src/interfaces/IPerspective.sol
+++ b/assertions/src/interfaces/IPerspective.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity >=0.8.0;
+
+/// @title IPerspective
+/// @custom:security-contact security@euler.xyz
+/// @author Euler Labs (https://www.eulerlabs.com/)
+/// @notice A contract that verifies the properties of a vault.
+interface IPerspective {
+    /// @notice Emitted when a vault is verified successfully.
+    /// @param vault The address of the vault that has been verified.
+    event PerspectiveVerified(address indexed vault);
+
+    /// @notice Error thrown when a perspective verification fails.
+    /// @param perspective The address of the perspective contract where the error occurred.
+    /// @param vault The address of the vault being verified.
+    /// @param codes The error codes indicating the reasons for verification failure.
+    error PerspectiveError(address perspective, address vault, uint256 codes);
+
+    /// @notice Error thrown when a panic occurs in the perspective contract.
+    error PerspectivePanic();
+
+    /// @notice Returns the name of the perspective.
+    /// @dev Name should be unique and descriptive.
+    /// @return The name of the perspective.
+    function name() external view returns (string memory);
+
+    /// @notice Verifies the properties of a vault.
+    /// @param vault The address of the vault to verify.
+    /// @param failEarly Determines whether to fail early on the first error encountered or allow the verification to
+    /// continue and report all errors.
+    function perspectiveVerify(
+        address vault,
+        bool failEarly
+    ) external;
+
+    /// @notice Checks if a vault is verified.
+    /// @param vault The address of the vault to check.
+    /// @return True if the vault is verified, false otherwise.
+    function isVerified(
+        address vault
+    ) external view returns (bool);
+
+    /// @notice Returns the number of verified vaults.
+    /// @return The number of verified vaults.
+    function verifiedLength() external view returns (uint256);
+
+    /// @notice Returns an array of all verified vault addresses.
+    /// @return An array of addresses of verified vaults.
+    function verifiedArray() external view returns (address[] memory);
+}

--- a/assertions/test/backtesting/AccountHealthAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/AccountHealthAssertion.backtest.t.sol
@@ -12,6 +12,17 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
 
+    // EVC Linea deployment
+    address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
+
+    // Mainnet Perspective addresses
+    address constant MAINNET_GOVERNED_PERSPECTIVE = 0xcD7E3a18b23d60c3eD2cae736fe9c0Ad116a54a4;
+    address constant MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc79C866dd9f2EF9E5Ee0C68bCEB84beC9D451044;
+
+    // Linea Perspective addresses
+    address constant LINEA_GOVERNED_PERSPECTIVE = 0x74f9fD22aA0Dd5Bbf6006a4c9818248eb476C50A;
+    address constant LINEA_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc8d904FE94b65612AED5A73203C0eF8f3A0308C0;
+
     // Block configuration
     // uint256 constant END_BLOCK = 23697612; // call in batch
     uint256 constant END_BLOCK = 23697590; // out of gas batch
@@ -21,6 +32,22 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
     uint256 constant TX4_BLOCK = 23697586; // TX4 specific block
     uint256 constant SINGLE_BLOCK_RANGE = 1; // Just test one block
 
+    /// @notice Helper to get assertion creation code with mainnet perspectives
+    function getMainnetAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = MAINNET_GOVERNED_PERSPECTIVE;
+        perspectives[1] = MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(AccountHealthAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Helper to get assertion creation code with Linea perspectives
+    function getLineaAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = LINEA_GOVERNED_PERSPECTIVE;
+        perspectives[1] = LINEA_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(AccountHealthAssertion).creationCode, abi.encode(perspectives));
+    }
+
     /// @notice Backtest batch operations against mainnet EVC
     /// @dev Tests assertionBatchAccountHealth against 10 blocks of real transactions
     function testBacktest_EVC_BatchOperations_simple() public {
@@ -29,7 +56,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(AccountHealthAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -47,7 +74,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(AccountHealthAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -65,7 +92,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(AccountHealthAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: true,
@@ -83,7 +110,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(AccountHealthAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: AccountHealthAssertion.assertionCallAccountHealth.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -101,7 +128,7 @@ contract AccountHealthAssertionBacktest is CredibleTestWithBacktesting {
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(AccountHealthAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: AccountHealthAssertion.assertionControlCollateralAccountHealth.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,

--- a/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAccountingIntegrityAssertion.backtest.t.sol
@@ -12,9 +12,36 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
 
+    // EVC Linea deployment
+    address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
+
+    // Mainnet Perspective addresses
+    address constant MAINNET_GOVERNED_PERSPECTIVE = 0xcD7E3a18b23d60c3eD2cae736fe9c0Ad116a54a4;
+    address constant MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc79C866dd9f2EF9E5Ee0C68bCEB84beC9D451044;
+
+    // Linea Perspective addresses
+    address constant LINEA_GOVERNED_PERSPECTIVE = 0x74f9fD22aA0Dd5Bbf6006a4c9818248eb476C50A;
+    address constant LINEA_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc8d904FE94b65612AED5A73203C0eF8f3A0308C0;
+
     // Block configuration
     uint256 constant END_BLOCK = 23697612;
     uint256 constant BLOCK_RANGE = 10;
+
+    /// @notice Helper to get assertion creation code with mainnet perspectives
+    function getMainnetAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = MAINNET_GOVERNED_PERSPECTIVE;
+        perspectives[1] = MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultAccountingIntegrityAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Helper to get assertion creation code with Linea perspectives
+    function getLineaAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = LINEA_GOVERNED_PERSPECTIVE;
+        perspectives[1] = LINEA_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultAccountingIntegrityAssertion).creationCode, abi.encode(perspectives));
+    }
 
     /// @notice Backtest batch operations against mainnet EVC
     /// @dev Tests that vault balance >= cash for all batch operations
@@ -24,7 +51,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAccountingIntegrityAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -45,7 +72,7 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAccountingIntegrityAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultAccountingIntegrityAssertion.assertionCallAccountingIntegrity.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -65,8 +92,9 @@ contract VaultAccountingIntegrityAssertionBacktest is CredibleTestWithBacktestin
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAccountingIntegrityAssertion).creationCode,
-                assertionSelector: VaultAccountingIntegrityAssertion.assertionControlCollateralAccountingIntegrity.selector,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
+                assertionSelector: VaultAccountingIntegrityAssertion.assertionControlCollateralAccountingIntegrity
+                    .selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
                 useTraceFilter: false,

--- a/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultAssetTransferAccountingAssertion.backtest.t.sol
@@ -14,11 +14,35 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
 
     address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
 
+    // Mainnet Perspective addresses
+    address constant MAINNET_GOVERNED_PERSPECTIVE = 0xcD7E3a18b23d60c3eD2cae736fe9c0Ad116a54a4;
+    address constant MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc79C866dd9f2EF9E5Ee0C68bCEB84beC9D451044;
+
+    // Linea Perspective addresses
+    address constant LINEA_GOVERNED_PERSPECTIVE = 0x74f9fD22aA0Dd5Bbf6006a4c9818248eb476C50A;
+    address constant LINEA_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc8d904FE94b65612AED5A73203C0eF8f3A0308C0;
+
     // Block configuration
     uint256 constant END_BLOCK = 27419134;
     uint256 constant BLOCK_RANGE = 3;
 
-    /// @notice Backtest batch operations against mainnet EVC
+    /// @notice Helper to get assertion creation code with mainnet perspectives
+    function getMainnetAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = MAINNET_GOVERNED_PERSPECTIVE;
+        perspectives[1] = MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultAssetTransferAccountingAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Helper to get assertion creation code with Linea perspectives
+    function getLineaAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = LINEA_GOVERNED_PERSPECTIVE;
+        perspectives[1] = LINEA_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultAssetTransferAccountingAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Backtest batch operations against Linea EVC
     /// @dev Tests that all asset transfers are accounted for in batch operations
     function testBacktest_VaultAssetTransferAccounting_BatchOperations() public {
         BacktestingTypes.BacktestingResults memory results = executeBacktest(
@@ -26,7 +50,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 targetContract: EVC_LINEA,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAssetTransferAccountingAssertion).creationCode,
+                assertionCreationCode: getLineaAssertionCreationCode(),
                 assertionSelector: VaultAssetTransferAccountingAssertion.assertionBatchAssetTransferAccounting.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -47,7 +71,7 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAssetTransferAccountingAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultAssetTransferAccountingAssertion.assertionCallAssetTransferAccounting.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -67,9 +91,8 @@ contract VaultAssetTransferAccountingAssertionBacktest is CredibleTestWithBackte
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultAssetTransferAccountingAssertion).creationCode,
-                assertionSelector: VaultAssetTransferAccountingAssertion
-                    .assertionControlCollateralAssetTransferAccounting
+                assertionCreationCode: getMainnetAssertionCreationCode(),
+                assertionSelector: VaultAssetTransferAccountingAssertion.assertionControlCollateralAssetTransferAccounting
                     .selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,

--- a/assertions/test/backtesting/VaultExchangeRateSpikeAssertion.backtest.t.sol
+++ b/assertions/test/backtesting/VaultExchangeRateSpikeAssertion.backtest.t.sol
@@ -12,9 +12,36 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
     // EVC mainnet deployment
     address constant EVC_MAINNET = 0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383;
 
+    // EVC Linea deployment
+    address constant EVC_LINEA = 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09;
+
+    // Mainnet Perspective addresses
+    address constant MAINNET_GOVERNED_PERSPECTIVE = 0xcD7E3a18b23d60c3eD2cae736fe9c0Ad116a54a4;
+    address constant MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc79C866dd9f2EF9E5Ee0C68bCEB84beC9D451044;
+
+    // Linea Perspective addresses
+    address constant LINEA_GOVERNED_PERSPECTIVE = 0x74f9fD22aA0Dd5Bbf6006a4c9818248eb476C50A;
+    address constant LINEA_ESCROWED_COLLATERAL_PERSPECTIVE = 0xc8d904FE94b65612AED5A73203C0eF8f3A0308C0;
+
     // Block configuration
     uint256 constant END_BLOCK = 23697612;
     uint256 constant BLOCK_RANGE = 10;
+
+    /// @notice Helper to get assertion creation code with mainnet perspectives
+    function getMainnetAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = MAINNET_GOVERNED_PERSPECTIVE;
+        perspectives[1] = MAINNET_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultExchangeRateSpikeAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Helper to get assertion creation code with Linea perspectives
+    function getLineaAssertionCreationCode() internal pure returns (bytes memory) {
+        address[] memory perspectives = new address[](2);
+        perspectives[0] = LINEA_GOVERNED_PERSPECTIVE;
+        perspectives[1] = LINEA_ESCROWED_COLLATERAL_PERSPECTIVE;
+        return abi.encodePacked(type(VaultExchangeRateSpikeAssertion).creationCode, abi.encode(perspectives));
+    }
 
     /// @notice Backtest batch operations against mainnet EVC
     /// @dev Tests that exchange rate changes are within 5% for batch operations
@@ -24,7 +51,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultExchangeRateSpikeAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -45,7 +72,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultExchangeRateSpikeAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultExchangeRateSpikeAssertion.assertionCallExchangeRateSpike.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,
@@ -65,7 +92,7 @@ contract VaultExchangeRateSpikeAssertionBacktest is CredibleTestWithBacktesting 
                 targetContract: EVC_MAINNET,
                 endBlock: END_BLOCK,
                 blockRange: BLOCK_RANGE,
-                assertionCreationCode: type(VaultExchangeRateSpikeAssertion).creationCode,
+                assertionCreationCode: getMainnetAssertionCreationCode(),
                 assertionSelector: VaultExchangeRateSpikeAssertion.assertionControlCollateralExchangeRateSpike.selector,
                 rpcUrl: vm.envString("MAINNET_RPC_URL"),
                 detailedBlocks: false,

--- a/assertions/test/mocks/MockPerspective.sol
+++ b/assertions/test/mocks/MockPerspective.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IPerspective} from "../../src/interfaces/IPerspective.sol";
+
+/// @title MockPerspective
+/// @notice A mock perspective for testing that returns true for all vaults or specified vaults
+contract MockPerspective is IPerspective {
+    mapping(address => bool) public verifiedVaults;
+    address[] public verifiedList;
+    bool public verifyAll;
+
+    constructor() {
+        verifyAll = true; // By default, verify all vaults for easy testing
+    }
+
+    /// @notice Set whether to verify all vaults by default
+    function setVerifyAll(
+        bool _verifyAll
+    ) external {
+        verifyAll = _verifyAll;
+    }
+
+    /// @notice Add a vault to the verified list
+    function addVerifiedVault(
+        address vault
+    ) external {
+        if (!verifiedVaults[vault]) {
+            verifiedVaults[vault] = true;
+            verifiedList.push(vault);
+        }
+    }
+
+    /// @notice Remove a vault from the verified list
+    function removeVerifiedVault(
+        address vault
+    ) external {
+        verifiedVaults[vault] = false;
+    }
+
+    function name() external pure override returns (string memory) {
+        return "MockPerspective";
+    }
+
+    function perspectiveVerify(
+        address,
+        bool
+    ) external pure override {
+        // No-op for mock
+    }
+
+    function isVerified(
+        address vault
+    ) external view override returns (bool) {
+        if (verifyAll) return true;
+        return verifiedVaults[vault];
+    }
+
+    function verifiedLength() external view override returns (uint256) {
+        return verifiedList.length;
+    }
+
+    function verifiedArray() external view override returns (address[] memory) {
+        return verifiedList;
+    }
+}

--- a/assertions/test/unit/AccountHealthAssertion.t.sol
+++ b/assertions/test/unit/AccountHealthAssertion.t.sol
@@ -9,6 +9,7 @@ import {IEVC} from "../../../src/interfaces/IEthereumVaultConnector.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
 import {MockVault} from "../mocks/MockVault.sol";
 import {MockEVault} from "../mocks/MockEVault.sol";
+import {MockPerspective} from "../mocks/MockPerspective.sol";
 
 /// @title TestAccountHealthAssertion
 /// @notice Test suite for AccountHealthAssertion
@@ -29,11 +30,29 @@ contract TestAccountHealthAssertion is BaseTest {
     MockERC20 public token4;
     MockERC20 public asset; // Asset for MockEVault tests
 
+    // Mock perspective for vault verification
+    MockPerspective public mockPerspective;
+
+    /// @notice Helper to get assertion creation code with MockPerspective
+    function getAssertionCreationCode() internal view returns (bytes memory) {
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        return abi.encodePacked(type(AccountHealthAssertion).creationCode, abi.encode(perspectives));
+    }
+
+    /// @notice Helper to register a vault with the mock perspective
+    function registerVaultWithPerspective(
+        address vault
+    ) internal {
+        mockPerspective.addVerifiedVault(vault);
+    }
+
     function setUp() public override {
         super.setUp();
 
-        // Deploy assertion
-        assertion = new AccountHealthAssertion();
+        // Deploy MockPerspective FIRST
+        mockPerspective = new MockPerspective();
+        mockPerspective.setVerifyAll(false);
 
         // Deploy test tokens
         token1 = new MockERC20("Test Token 1", "TT1");
@@ -47,6 +66,17 @@ contract TestAccountHealthAssertion is BaseTest {
         vault2 = new MockVault(address(evc), address(token2));
         vault3 = new MockVault(address(evc), address(token3));
         vault4 = new MockVault(address(evc), address(token4));
+
+        // Register vaults with the perspective
+        mockPerspective.addVerifiedVault(address(vault1));
+        mockPerspective.addVerifiedVault(address(vault2));
+        mockPerspective.addVerifiedVault(address(vault3));
+        mockPerspective.addVerifiedVault(address(vault4));
+
+        // Deploy assertion with perspective
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        assertion = new AccountHealthAssertion(perspectives);
 
         // Setup test environment
         setupUserETH();
@@ -86,7 +116,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -133,7 +163,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -175,7 +205,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -207,7 +237,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -227,7 +257,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -252,7 +282,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for controlCollateral call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionControlCollateralAccountHealth.selector
         });
 
@@ -297,7 +327,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register call assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -341,7 +371,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register call assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -380,7 +410,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register call assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -412,7 +442,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for controlCollateral call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionControlCollateralAccountHealth.selector
         });
 
@@ -434,7 +464,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -461,7 +491,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -514,7 +544,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -551,7 +581,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -599,7 +629,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -646,7 +676,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -699,7 +729,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -748,7 +778,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -776,7 +806,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -814,7 +844,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -835,7 +865,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_UnhealthyViolator_Passes() public {
         // Deploy MockEVault instances for this test
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens to user1
         asset.mint(user1, 1000e18);
@@ -875,7 +907,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -895,7 +927,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_HealthyViolator_Reverts() public {
         // Deploy MockEVault instances for this test
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens to user1
         asset.mint(user1, 1000e18);
@@ -938,7 +972,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -959,7 +993,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_LiquidatorHealth_Passes() public {
         // Deploy MockEVault instances for this test
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens to users
         asset.mint(user1, 1000e18);
@@ -1011,7 +1047,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1035,7 +1071,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_MultipleSequentialLiquidations_Passes() public {
         // Deploy MockEVault instances
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens to users
         asset.mint(user1, 1000e18);
@@ -1098,7 +1136,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // First liquidation - register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1114,7 +1152,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Second liquidation - register assertion again
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1133,7 +1171,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_ZeroCollateralRecovery_Passes() public {
         // Deploy MockEVault instances
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens
         asset.mint(user1, 100e18);
@@ -1185,7 +1225,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1206,7 +1246,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_MultipleCollateralTypes_Passes() public {
         // Deploy MockEVault instances
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens
         asset.mint(user1, 1000e18);
@@ -1253,7 +1295,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1272,7 +1314,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_Liquidate_SelfLiquidation_Passes() public {
         // Deploy MockEVault instances
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens to user1
         asset.mint(user1, 2000e18);
@@ -1315,7 +1359,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1338,7 +1382,9 @@ contract TestAccountHealthAssertion is BaseTest {
     function testAccountHealth_ExactlyZeroHealth_Passes() public {
         // Deploy MockEVault instances
         MockEVault debtVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(debtVault));
         MockEVault collateralVault = new MockEVault(asset, evc);
+        registerVaultWithPerspective(address(collateralVault));
 
         // Mint tokens
         asset.mint(user1, 1000e18);
@@ -1378,7 +1424,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -1447,7 +1493,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion before the batch
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1484,7 +1530,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion before the batch
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1556,7 +1602,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion before the batch
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1617,7 +1663,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion before the batch
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1725,7 +1771,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1779,7 +1825,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1850,7 +1896,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1921,7 +1967,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -1979,7 +2025,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2048,7 +2094,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2109,7 +2155,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2179,7 +2225,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2243,7 +2289,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2317,7 +2363,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2384,7 +2430,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register batch assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2458,7 +2504,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register batch assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2523,7 +2569,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register batch assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2584,7 +2630,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register batch assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2638,7 +2684,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register call assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
 
@@ -2685,7 +2731,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Test 1: Single call with assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
         vm.prank(user1);
@@ -2695,7 +2741,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Test 2: Three consecutive calls, each with assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
         vm.prank(user1);
@@ -2703,7 +2749,7 @@ contract TestAccountHealthAssertion is BaseTest {
 
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
         vm.prank(user1);
@@ -2711,7 +2757,7 @@ contract TestAccountHealthAssertion is BaseTest {
 
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionCallAccountHealth.selector
         });
         vm.prank(user1);
@@ -2747,7 +2793,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register batch assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2794,7 +2840,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 
@@ -2813,7 +2859,7 @@ contract TestAccountHealthAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(AccountHealthAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: AccountHealthAssertion.assertionBatchAccountHealth.selector
         });
 

--- a/assertions/test/unit/VaultAccountingIntegrityAssertion.t.sol
+++ b/assertions/test/unit/VaultAccountingIntegrityAssertion.t.sol
@@ -10,6 +10,7 @@ import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
 import {MockEVault} from "../mocks/MockEVault.sol";
 import {CashThiefVault} from "../mocks/MaliciousVaults.sol";
+import {MockPerspective} from "../mocks/MockPerspective.sol";
 
 /// @title TestVaultAccountingIntegrityAssertion
 /// @notice Test suite for VaultAccountingIntegrityAssertion
@@ -19,9 +20,21 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
     MockEVault public vault2;
     CashThiefVault public maliciousVault;
     MockERC20 public asset;
+    MockPerspective public mockPerspective;
+
+    /// @notice Helper to get assertion creation code with MockPerspective
+    function getAssertionCreationCode() internal view returns (bytes memory) {
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        return abi.encodePacked(type(VaultAccountingIntegrityAssertion).creationCode, abi.encode(perspectives));
+    }
 
     function setUp() public override {
         super.setUp();
+
+        // Deploy MockPerspective FIRST
+        mockPerspective = new MockPerspective();
+        mockPerspective.setVerifyAll(false);
 
         // Deploy mock asset
         asset = new MockERC20("Mock Asset", "MOCK");
@@ -32,6 +45,11 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
 
         // Deploy malicious vault
         maliciousVault = new CashThiefVault(asset, evc);
+
+        // Register vaults with the perspective
+        mockPerspective.addVerifiedVault(address(vault1));
+        mockPerspective.addVerifiedVault(address(vault2));
+        mockPerspective.addVerifiedVault(address(maliciousVault));
 
         // Setup tokens (mint + approve)
         setupToken(asset, address(vault1), 1000e18);
@@ -59,7 +77,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -87,7 +105,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -115,7 +133,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -145,7 +163,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -183,7 +201,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -213,7 +231,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -234,7 +252,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionCallAccountingIntegrity.selector
         });
 
@@ -261,7 +279,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion for controlCollateral operations
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionControlCollateralAccountingIntegrity.selector
         });
 
@@ -287,7 +305,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -322,7 +340,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -354,7 +372,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -386,7 +404,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -418,7 +436,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -446,7 +464,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionBatchAccountingIntegrity.selector
         });
 
@@ -488,7 +506,7 @@ contract TestVaultAccountingIntegrityAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultAccountingIntegrityAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultAccountingIntegrityAssertion.assertionCallAccountingIntegrity.selector
         });
 

--- a/assertions/test/unit/VaultExchangeRateSpikeAssertion.t.sol
+++ b/assertions/test/unit/VaultExchangeRateSpikeAssertion.t.sol
@@ -10,6 +10,7 @@ import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
 import {MockEVault} from "../mocks/MockEVault.sol";
 import {RateManipulatorVault} from "../mocks/MaliciousVaults.sol";
+import {MockPerspective} from "../mocks/MockPerspective.sol";
 
 /// @title TestVaultExchangeRateSpikeAssertion
 /// @notice Test suite for VaultExchangeRateSpikeAssertion
@@ -19,9 +20,21 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
     MockEVault public vault2;
     RateManipulatorVault public maliciousVault;
     MockERC20 public asset;
+    MockPerspective public mockPerspective;
+
+    /// @notice Helper to get assertion creation code with MockPerspective
+    function getAssertionCreationCode() internal view returns (bytes memory) {
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        return abi.encodePacked(type(VaultExchangeRateSpikeAssertion).creationCode, abi.encode(perspectives));
+    }
 
     function setUp() public override {
         super.setUp();
+
+        // Deploy MockPerspective FIRST
+        mockPerspective = new MockPerspective();
+        mockPerspective.setVerifyAll(false);
 
         // Deploy mock asset
         asset = new MockERC20("Mock Asset", "MOCK");
@@ -32,6 +45,11 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
 
         // Deploy malicious vault
         maliciousVault = new RateManipulatorVault(asset, evc);
+
+        // Register vaults with the perspective
+        mockPerspective.addVerifiedVault(address(vault1));
+        mockPerspective.addVerifiedVault(address(vault2));
+        mockPerspective.addVerifiedVault(address(maliciousVault));
 
         // Setup tokens (mint + approve)
         setupToken(asset, address(vault1), 10000e18);
@@ -52,7 +70,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -80,7 +98,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -108,7 +126,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -146,7 +164,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion IMMEDIATELY before batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -177,7 +195,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion IMMEDIATELY before batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -200,7 +218,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -233,7 +251,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionCallExchangeRateSpike.selector
         });
 
@@ -260,7 +278,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionControlCollateralExchangeRateSpike.selector
         });
 
@@ -287,7 +305,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -314,7 +332,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -357,7 +375,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion IMMEDIATELY before batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -387,7 +405,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion IMMEDIATELY before batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -417,7 +435,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion IMMEDIATELY before batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -437,7 +455,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -464,7 +482,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionBatchExchangeRateSpike.selector
         });
 
@@ -518,7 +536,7 @@ contract TestVaultExchangeRateSpikeAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultExchangeRateSpikeAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultExchangeRateSpikeAssertion.assertionCallExchangeRateSpike.selector
         });
 

--- a/assertions/test/unit/VaultSharePriceAssertion.t.sol
+++ b/assertions/test/unit/VaultSharePriceAssertion.t.sol
@@ -9,6 +9,7 @@ import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.so
 import {ERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {ERC4626} from "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
+import {MockPerspective} from "../mocks/MockPerspective.sol";
 
 /// @title TestVaultSharePriceAssertion
 /// @notice Comprehensive test suite for the VaultSharePriceAssertion assertion
@@ -28,11 +29,23 @@ contract TestVaultSharePriceAssertion is BaseTest {
     // Controller vault for controlCollateral tests
     MockControllerVault public controllerVault;
 
+    // Mock perspective for vault verification
+    MockPerspective public mockPerspective;
+
+    /// @notice Helper to get assertion creation code with MockPerspective
+    /// @dev Passes the mockPerspective address to the assertion constructor
+    function getAssertionCreationCode() internal view returns (bytes memory) {
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        return abi.encodePacked(type(VaultSharePriceAssertion).creationCode, abi.encode(perspectives));
+    }
+
     function setUp() public override {
         super.setUp();
 
-        // Deploy assertion
-        assertion = new VaultSharePriceAssertion();
+        // Deploy MockPerspective FIRST (before vaults)
+        mockPerspective = new MockPerspective();
+        mockPerspective.setVerifyAll(false); // Only verify explicitly added vaults
 
         // Deploy test tokens
         token1 = new MockERC20("Test Token 1", "TT1");
@@ -43,6 +56,16 @@ contract TestVaultSharePriceAssertion is BaseTest {
         vault1 = new MockERC4626Vault(token1);
         vault2 = new MockERC4626Vault(token2);
         vault3 = new MockERC4626Vault(token3);
+
+        // Register vaults with the perspective
+        mockPerspective.addVerifiedVault(address(vault1));
+        mockPerspective.addVerifiedVault(address(vault2));
+        mockPerspective.addVerifiedVault(address(vault3));
+
+        // Deploy assertion with perspective
+        address[] memory perspectives = new address[](1);
+        perspectives[0] = address(mockPerspective);
+        assertion = new VaultSharePriceAssertion(perspectives);
 
         // Deploy controller vault
         controllerVault = new MockControllerVault();
@@ -75,7 +98,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for the batch call (this will trigger on the next call)
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -105,7 +128,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -135,7 +158,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -164,7 +187,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for the batch call
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -210,7 +233,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -231,7 +254,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionCallSharePriceInvariant.selector
         });
 
@@ -254,7 +277,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionCallSharePriceInvariant.selector
         });
 
@@ -285,7 +308,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionControlCollateralSharePriceInvariant.selector
         });
 
@@ -317,7 +340,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionControlCollateralSharePriceInvariant.selector
         });
 
@@ -343,7 +366,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -367,7 +390,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -395,7 +418,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for next transaction
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -437,7 +460,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion for batch operation
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -500,7 +523,7 @@ contract TestVaultSharePriceAssertion is BaseTest {
         // Register assertion
         cl.assertion({
             adopter: address(evc),
-            createData: type(VaultSharePriceAssertion).creationCode,
+            createData: getAssertionCreationCode(),
             fnSelector: VaultSharePriceAssertion.assertionBatchSharePriceInvariant.selector
         });
 
@@ -599,7 +622,11 @@ contract MockERC4626Vault is ERC4626 {
     /// @notice Simulates a deposit with specific assets and shares
     /// @dev Used to test the VIRTUAL_DEPOSIT formula by creating deposits at specific ratios
     /// that would trigger false positives without the correct formula
-    function simulateDeposit(uint256 assets, uint256 shares, address receiver) external {
+    function simulateDeposit(
+        uint256 assets,
+        uint256 shares,
+        address receiver
+    ) external {
         _totalAssets += assets;
         _mint(receiver, shares);
     }
@@ -610,20 +637,34 @@ contract MockERC4626Vault is ERC4626 {
     }
 
     // Required ERC4626 functions (simplified for testing)
-    function deposit(uint256, address) public pure override returns (uint256) {
+    function deposit(
+        uint256,
+        address
+    ) public pure override returns (uint256) {
         revert("Not implemented for testing");
     }
 
-    function mint(uint256 shares, address receiver) public override returns (uint256) {
+    function mint(
+        uint256 shares,
+        address receiver
+    ) public override returns (uint256) {
         _mint(receiver, shares);
         return shares;
     }
 
-    function withdraw(uint256, address, address) public pure override returns (uint256) {
+    function withdraw(
+        uint256,
+        address,
+        address
+    ) public pure override returns (uint256) {
         revert("Not implemented for testing");
     }
 
-    function redeem(uint256, address, address) public pure override returns (uint256) {
+    function redeem(
+        uint256,
+        address,
+        address
+    ) public pure override returns (uint256) {
         revert("Not implemented for testing");
     }
 
@@ -694,7 +735,10 @@ contract MockControllerVault {
     // Simple controller vault that can be used for controlCollateral tests
     // Implements the required checkAccountStatus function that EVC expects from controllers
 
-    function checkAccountStatus(address, address[] memory) external pure returns (bytes4) {
+    function checkAccountStatus(
+        address,
+        address[] memory
+    ) external pure returns (bytes4) {
         return this.checkAccountStatus.selector;
     }
 }


### PR DESCRIPTION
EVC batch operations can contain arbitrary contracts (WETH, EOAs, Permit2, routers, etc.), not just verified Euler vaults. This caused gas waste and EIP-214 gas exhaustion issues when assertions tried to call vault methods on non-vault contracts.

Changes:

Add IPerspective integration to all 5 assertion contracts:
- VaultSharePriceAssertion
- VaultExchangeRateSpikeAssertion
- VaultAccountingIntegrityAssertion
- VaultAssetTransferAccountingAssertion
- AccountHealthAssertion

Each assertion now:
- Takes an array of IPerspective addresses in the constructor
- Checks isVerifiedVault() before processing each contract
- Skips non-verified contracts, avoiding unnecessary calls and gas issues

Create assertions/src/interfaces/IPerspective.sol:
- Defines the isVerified() interface used by Euler perspectives
- Supports both GovernedPerspective and EscrowedCollateralPerspective

Update all unit and fuzz tests to use MockPerspective:
- Add MockPerspective mock that allows explicit vault registration
- Update test setUp() to register test vaults with perspective
- Fix constructor arg encoding for cl.assertion() calls

Update all backtesting files with correct network addresses:
- Fix Linea perspective addresses (were incorrectly using mainnet addresses)
- Add Linea deployment addresses to all backtest files for future use:
  - EVC_LINEA: 0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09
  - LINEA_GOVERNED_PERSPECTIVE: 0x74f9fD22aA0Dd5Bbf6006a4c9818248eb476C50A
  - LINEA_ESCROWED_COLLATERAL_PERSPECTIVE: 0xc8d904FE94b65612AED5A73203C0eF8f3A0308C0
- Add getLineaAssertionCreationCode() helper to all backtest files